### PR TITLE
Added required dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ MAINTAINER Fabian Beuke <mail@beuke.org>
 
 RUN apk add --update --no-cache \
     libgcc libstdc++ libx11 glib libxrender libxext libintl \
+    libcrypto1.0 libssl1.0 \
     ttf-dejavu ttf-droid ttf-freefont ttf-liberation ttf-ubuntu-font-family
 
 # on alpine static compiled patched qt headless wkhtmltopdf (47.2 MB)


### PR DESCRIPTION
wkhtmltopdf throws error without them on alpine:edge:
Error loading shared library libssl.so.1.0.0: No such file or directory (needed by /usr/bin/wkhtmltopdf)
Error loading shared library libcrypto.so.1.0.0: No such file or directory (needed by /usr/bin/wkhtmltopdf)
